### PR TITLE
Add proper TypeScript definitions

### DIFF
--- a/assortment__darkmodejs.d.ts
+++ b/assortment__darkmodejs.d.ts
@@ -1,5 +1,0 @@
-declare module "@assortment/darkmodejs" {
-  export = assortment__darkmodejs;
-
-  declare function assortment__darkmodejs({ onChange = () => {} }: any): any;
-}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,18 @@
+declare enum Theme {
+  DARK = 'dark',
+  LIGHT = 'light',
+  NO_PREF = 'no-preference',
+  NO_SUPP = 'no-support'
+}
+
+interface Config {
+  onChange: (activeTheme: Theme, themes: typeof Theme) => void;
+}
+
+interface DarkModeJS {
+  removeListeners: () => void;
+}
+
+declare function darkmodejs(config: Config): DarkModeJS;
+
+export = darkmodejs;


### PR DESCRIPTION
#4 added TypeScript "definitions" using `dts-gen`. While this is acceptable for getting a basic `d.ts` file ready for larger libraries, it really shouldn't be used for production `d.ts` files—it provides only a way to import the module, and completely throws out type information, which is the entire point of TypeScript.

This new type declaration file provides a strongly-typed interface for the module, albeit at the cost of some duplication. If new theme selections are added to `prefers-color-scheme`, both the module and TypeScript declarations will need to be updated.

To import the module with TypeScript, users will need to use one of the following patterns:

```ts
import darkmodejs = require('@assortment/darkmodejs');
```

or, with `--esModuleInterop` in their compile options:

```ts
import darkmodejs from '@assortment/darkmodejs';
```

I can add these to the README if you'd like.